### PR TITLE
Support for integrating with existing networking; deployment script fixes for cron and time zones

### DIFF
--- a/deploy.ps1
+++ b/deploy.ps1
@@ -67,7 +67,7 @@ $DeploymentResult = New-AzDeployment @CmdLetParameters
 if ($DeploymentResult.ProvisioningState -eq 'Succeeded') {
     Write-Host "🔥 Deployment succeeded."
 
-    $DeploymentResult.Outputs
+    $DeploymentResult.Outputs | Format-Table -Property Key, @{Name = 'Value'; Expression = { $_.Value.Value } }
 }
 else {
     $DeploymentResult

--- a/main-sample.bicepparam
+++ b/main-sample.bicepparam
@@ -40,3 +40,5 @@ param smtpFromEmailAddress = '<Specify valid SMTP From Email Address>'
 // This parameter is required to ensure the parameter file is valid, but should be blank so the password doesn't leak. 
 // A new password is generated for each deployment and stored in Key Vault.
 param sqlPassword = ''
+
+param appServiceTimeZone = 'UTC'

--- a/main.bicep
+++ b/main.bicep
@@ -59,8 +59,8 @@ param smtpPort string = ''
 @description('The email address to use as the sender for outgoing emails.')
 param smtpFromEmailAddress string = ''
 
-param existingPrivateDnsZonesResourceGroupId string
-param existingVirtualNetworkId string
+param existingPrivateDnsZonesResourceGroupId string = ''
+param existingVirtualNetworkId string = ''
 
 var sequenceFormatted = format('{0:00}', sequence)
 var rgNamingStructure = replace(
@@ -356,7 +356,7 @@ module mySqlModule './modules/sql/main.bicep' = {
     customTags: {
       workloadType: 'mySqlFlexibleServer'
     }
-    skuName: 'Standard_B1s'
+    skuName: 'Standard_B1ms'
     SkuTier: 'Burstable'
     StorageSizeGB: 20
     StorageIops: 396

--- a/main.bicep
+++ b/main.bicep
@@ -337,9 +337,7 @@ module keyVaultModule './modules/kv/main.bicep' = {
       }
     ]
     privateDnsZoneName: 'privatelink.vaultcore.azure.net'
-    // TODO: Enable
-    //secrets: secrets
-    secrets: {}
+    secrets: secrets
 
     deploymentNameStructure: deploymentNameStructure
   }

--- a/main.bicep
+++ b/main.bicep
@@ -62,6 +62,8 @@ param smtpFromEmailAddress string = ''
 param existingPrivateDnsZonesResourceGroupId string = ''
 param existingVirtualNetworkId string = ''
 
+param appServiceTimeZone string = 'UTC'
+
 var sequenceFormatted = format('{0:00}', sequence)
 var rgNamingStructure = replace(
   replace(
@@ -450,6 +452,8 @@ module webAppModule './modules/webapp/main.bicep' = {
     uamiId: uamiModule.outputs.id
 
     enablePrivateEndpoint: enableAppServicePrivateEndpoint
+
+    timeZone: appServiceTimeZone
   }
 }
 

--- a/main.bicep
+++ b/main.bicep
@@ -57,9 +57,28 @@ param smtpPort string = ''
 @description('The email address to use as the sender for outgoing emails.')
 param smtpFromEmailAddress string = ''
 
+param existingPrivateDnsZonesResourceGroupId string
+param existingVirtualNetworkId string
+
 var sequenceFormatted = format('{0:00}', sequence)
-var rgNamingStructure = replace(replace(replace(replace(replace(namingConvention, '{rtype}', 'rg'), '{workloadName}', '${workloadName}-{rgName}'), '{loc}', location), '{seq}', sequenceFormatted), '{env}', environment)
-var vnetName = nameModule[0].outputs.shortName
+var rgNamingStructure = replace(
+  replace(
+    replace(
+      replace(replace(namingConvention, '{rtype}', 'rg'), '{workloadName}', '${workloadName}-{rgName}'),
+      '{loc}',
+      location
+    ),
+    '{seq}',
+    sequenceFormatted
+  ),
+  '{env}',
+  environment
+)
+// The name of the VNet is either a new name or the name of the existing VNet parsed from the resource ID
+var vnetName = empty(existingVirtualNetworkId)
+  ? nameModule[0].outputs.shortName
+  : split(existingVirtualNetworkId, '/')[8]
+
 var strgName = nameModule[1].outputs.shortName
 var webAppName = nameModule[2].outputs.shortName
 var kvName = nameModule[3].outputs.shortName
@@ -71,8 +90,10 @@ var lawName = nameModule[8].outputs.shortName
 
 var deploymentNameStructure = '${workloadName}-${environment}-${sequenceFormatted}-{rtype}-${deploymentTime}'
 
-var subnets = {
+// TODO: Define type
+param subnets object = {
   // TODO: Define securityRules
+  // TODO: Add existingSubnetName property for existing subnet
   PrivateLinkSubnet: {
     addressPrefix: cidrSubnet(vnetAddressSpace, 27, 0)
     serviceEndpoints: [
@@ -165,12 +186,12 @@ var tags = {
   environment: environment
 }
 
-var secrets = {
-  sqlAdminName: mySqlModule.outputs.sqlAdmin
-  sqlPassword: sqlPassword
-  redcapCommunityUsername: redcapCommunityUsername
-  redcapCommunityPassword: redcapCommunityPassword
-}
+// var secrets = {
+//   sqlAdminName: mySqlModule.outputs.sqlAdmin
+//   sqlPassword: sqlPassword
+//   redcapCommunityUsername: redcapCommunityUsername
+//   redcapCommunityPassword: redcapCommunityPassword
+// }
 
 var resourceTypes = [
   'vnet'
@@ -185,18 +206,20 @@ var resourceTypes = [
 ]
 
 @batchSize(1)
-module nameModule 'modules/common/createValidAzResourceName.bicep' = [for workload in resourceTypes: {
-  name: take(replace(deploymentNameStructure, '{rtype}', 'nameGen-${workload}'), 64)
-  params: {
-    location: location
-    environment: environment
-    namingConvention: namingConvention
-    resourceType: workload
-    sequence: sequence
-    workloadName: workloadName
-    addRandomChars: 4
+module nameModule 'modules/common/createValidAzResourceName.bicep' = [
+  for workload in resourceTypes: {
+    name: take(replace(deploymentNameStructure, '{rtype}', 'nameGen-${workload}'), 64)
+    params: {
+      location: location
+      environment: environment
+      namingConvention: namingConvention
+      resourceType: workload
+      sequence: sequence
+      workloadName: workloadName
+      addRandomChars: 4
+    }
   }
-}]
+]
 
 module rolesModule './modules/common/roles.bicep' = {
   name: take(replace(deploymentNameStructure, '{rtype}', 'roles'), 64)
@@ -204,21 +227,21 @@ module rolesModule './modules/common/roles.bicep' = {
 
 var storageAccountKeySecretName = 'storageKey'
 // The secrets object is converted to an array using the items() function, which alphabetically sorts it
-var defaultSecretNames = map(items(secrets), s => s.key)
-var additionalSecretNames = [ storageAccountKeySecretName ]
-var secretNames = concat(defaultSecretNames, additionalSecretNames)
+// var defaultSecretNames = map(items(secrets), s => s.key)
+// var additionalSecretNames = [storageAccountKeySecretName]
+// var secretNames = concat(defaultSecretNames, additionalSecretNames)
 
 // The output will be in alphabetical order
 // LATER: Output an object instead
-module kvSecretReferencesModule './modules/common/appSvcKeyVaultRefs.bicep' = {
-  name: take(replace(deploymentNameStructure, '{rtype}', 'kv-secrets'), 64)
-  params: {
-    keyVaultName: kvName
-    secretNames: secretNames
-  }
-}
+// module kvSecretReferencesModule './modules/common/appSvcKeyVaultRefs.bicep' = {
+//   name: take(replace(deploymentNameStructure, '{rtype}', 'kv-secrets'), 64)
+//   params: {
+//     keyVaultName: kvName
+//     secretNames: secretNames
+//   }
+// }
 
-module virtualNetworkModule './modules/networking/main.bicep' = {
+module virtualNetworkModule './modules/networking/main.bicep' = if (empty(existingVirtualNetworkId)) {
   name: take(replace(deploymentNameStructure, '{rtype}', 'network'), 64)
   params: {
     resourceGroupName: replace(rgNamingStructure, '{rgName}', 'network')
@@ -254,18 +277,29 @@ module monitoring './modules/monitoring/main.bicep' = {
   }
 }
 
+var privateEndpointSubnetId = empty(existingVirtualNetworkId)
+  ? virtualNetworkModule.outputs.subnets.PrivateLinkSubnet.id
+  : '${existingVirtualNetworkId}/subnets/${subnets.PrivateLinkSubnet.existingSubnetName}'
+
+var virtualNetworkId = empty(existingVirtualNetworkId)
+  ? virtualNetworkModule.outputs.virtualNetworkId
+  : existingVirtualNetworkId
+
 module storageAccountModule './modules/storage/main.bicep' = {
   name: take(replace(deploymentNameStructure, '{rtype}', 'storage'), 64)
   params: {
     resourceGroupName: replace(rgNamingStructure, '{rgName}', 'storage')
     location: location
     storageAccountName: strgName
-    peSubnetId: virtualNetworkModule.outputs.subnets.PrivateLinkSubnet.id
+    peSubnetId: privateEndpointSubnetId
     storageContainerName: 'redcap'
     kind: 'StorageV2'
     storageAccountSku: 'Standard_LRS'
-    virtualNetworkId: virtualNetworkModule.outputs.virtualNetworkId
+
+    virtualNetworkId: virtualNetworkId
     privateDnsZoneName: 'privatelink.blob.${az.environment().suffixes.storage}'
+    existingPrivateDnsZonesResourceGroupId: existingPrivateDnsZonesResourceGroupId
+
     tags: tags
     customTags: {
       workloadType: 'storageAccount'
@@ -288,8 +322,9 @@ module keyVaultModule './modules/kv/main.bicep' = {
     customTags: {
       workloadType: 'keyVault'
     }
-    peSubnetId: virtualNetworkModule.outputs.subnets.PrivateLinkSubnet.id
-    virtualNetworkId: virtualNetworkModule.outputs.virtualNetworkId
+    peSubnetId: privateEndpointSubnetId
+    virtualNetworkId: virtualNetworkId
+    existingPrivateDnsZonesResourceGroupId: existingPrivateDnsZonesResourceGroupId
     roleAssignments: [
       {
         RoleDefinitionId: rolesModule.outputs.roles['Key Vault Administrator']
@@ -298,10 +333,13 @@ module keyVaultModule './modules/kv/main.bicep' = {
       {
         RoleDefinitionId: rolesModule.outputs.roles['Key Vault Secrets User']
         objectId: uamiModule.outputs.principalId
+        principtalType: 'ServicePrincipal'
       }
     ]
     privateDnsZoneName: 'privatelink.vaultcore.azure.net'
-    secrets: secrets
+    // TODO: Enable
+    //secrets: secrets
+    secrets: {}
 
     deploymentNameStructure: deploymentNameStructure
   }
@@ -322,8 +360,11 @@ module mySqlModule './modules/sql/main.bicep' = {
     SkuTier: 'Burstable'
     StorageSizeGB: 20
     StorageIops: 396
-    peSubnetId: virtualNetworkModule.outputs.subnets.MySQLFlexSubnet.id
+    peSubnetId: empty(existingVirtualNetworkId)
+      ? virtualNetworkModule.outputs.subnets.MySQLFlexSubnet.id
+      : '${existingVirtualNetworkId}/subnets/${subnets.MySQLFlexSubnet.existingSubnetName}'
     privateDnsZoneName: 'privatelink.mysql.database.azure.com'
+    existingPrivateDnsZonesResourceGroupId: existingPrivateDnsZonesResourceGroupId
     sqlAdminUser: sqlAdmin
     sqlAdminPasword: sqlPassword
     mysqlVersion: '8.0.21'
@@ -341,7 +382,7 @@ module mySqlModule './modules/sql/main.bicep' = {
     database_charset: 'utf8'
     database_collation: 'utf8_general_ci'
 
-    virtualNetworkId: virtualNetworkModule.outputs.virtualNetworkId
+    virtualNetworkId: virtualNetworkId
 
     deploymentNameStructure: deploymentNameStructure
   }
@@ -351,60 +392,60 @@ resource webAppResourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: replace(rgNamingStructure, '{rgName}', 'web')
   location: location
   tags: union(tags, {
-      workloadType: 'web'
-    })
+    workloadType: 'web'
+  })
 }
 
-module webAppModule './modules/webapp/main.bicep' = {
-  name: take(replace(deploymentNameStructure, '{rtype}', 'appService'), 64)
-  scope: webAppResourceGroup
-  params: {
-    webAppName: webAppName
-    appServicePlanName: planName
-    location: location
-    // TODO: Consider deploying as P0V3 to ensure the deployment runs on a scale unit that supports P_v3 for future upgrades. GH issue #50
-    skuName: 'S1'
-    skuTier: 'Standard'
-    peSubnetId: virtualNetworkModule.outputs.subnets.PrivateLinkSubnet.id
-    appInsights_connectionString: monitoring.outputs.appInsightsResourceId
-    appInsights_instrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
-    linuxFxVersion: 'php|8.2'
-    tags: tags
-    customTags: {
-      workloadType: 'webApp'
-    }
-    privateDnsZoneName: 'privatelink.azurewebsites.net'
-    virtualNetworkId: virtualNetworkModule.outputs.virtualNetworkId
-    redcapZipUrl: redcapZipUrl
-    dbHostName: mySqlModule.outputs.fqdn
-    dbName: mySqlModule.outputs.databaseName
+// module webAppModule './modules/webapp/main.bicep' = {
+//   name: take(replace(deploymentNameStructure, '{rtype}', 'appService'), 64)
+//   scope: webAppResourceGroup
+//   params: {
+//     webAppName: webAppName
+//     appServicePlanName: planName
+//     location: location
+//     // TODO: Consider deploying as P0V3 to ensure the deployment runs on a scale unit that supports P_v3 for future upgrades. GH issue #50
+//     skuName: 'S1'
+//     skuTier: 'Standard'
+//     peSubnetId: virtualNetworkModule.outputs.subnets.PrivateLinkSubnet.id
+//     appInsights_connectionString: monitoring.outputs.appInsightsResourceId
+//     appInsights_instrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
+//     linuxFxVersion: 'php|8.2'
+//     tags: tags
+//     customTags: {
+//       workloadType: 'webApp'
+//     }
+//     privateDnsZoneName: 'privatelink.azurewebsites.net'
+//     virtualNetworkId: virtualNetworkModule.outputs.virtualNetworkId
+//     redcapZipUrl: redcapZipUrl
+//     dbHostName: mySqlModule.outputs.fqdn
+//     dbName: mySqlModule.outputs.databaseName
 
-    dbUserNameSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[2]
-    dbPasswordSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[3]
+//     dbUserNameSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[2]
+//     dbPasswordSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[3]
 
-    redcapCommunityUsernameSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[1]
-    redcapCommunityPasswordSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[0]
+//     redcapCommunityUsernameSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[1]
+//     redcapCommunityPasswordSecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[0]
 
-    storageAccountKeySecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[4]
-    storageAccountContainerName: storageAccountModule.outputs.containerName
-    storageAccountName: storageAccountModule.outputs.name
+//     storageAccountKeySecretRef: kvSecretReferencesModule.outputs.keyVaultRefs[4]
+//     storageAccountContainerName: storageAccountModule.outputs.containerName
+//     storageAccountName: storageAccountModule.outputs.name
 
-    // Enable VNet integration
-    integrationSubnetId: virtualNetworkModule.outputs.subnets.IntegrationSubnet.id
+//     // Enable VNet integration
+//     integrationSubnetId: virtualNetworkModule.outputs.subnets.IntegrationSubnet.id
 
-    scmRepoUrl: scmRepoUrl
-    scmRepoBranch: scmRepoBranch
-    prerequisiteCommand: prerequisiteCommand
+//     scmRepoUrl: scmRepoUrl
+//     scmRepoBranch: scmRepoBranch
+//     prerequisiteCommand: prerequisiteCommand
 
-    smtpFQDN: smtpFQDN
-    smtpFromEmailAddress: smtpFromEmailAddress
-    smtpPort: smtpPort
+//     smtpFQDN: smtpFQDN
+//     smtpFromEmailAddress: smtpFromEmailAddress
+//     smtpPort: smtpPort
 
-    deploymentNameStructure: deploymentNameStructure
+//     deploymentNameStructure: deploymentNameStructure
 
-    uamiId: uamiModule.outputs.id
-  }
-}
+//     uamiId: uamiModule.outputs.id
+//   }
+// }
 
 module uamiModule 'modules/uami/main.bicep' = {
   name: take(replace(deploymentNameStructure, '{rtype}', 'uami'), 64)
@@ -416,5 +457,5 @@ module uamiModule 'modules/uami/main.bicep' = {
   }
 }
 
-// The web app URL
-output webAppUrl string = webAppModule.outputs.webAppUrl
+// // The web app URL
+// output webAppUrl string = webAppModule.outputs.webAppUrl

--- a/main.bicep
+++ b/main.bicep
@@ -43,6 +43,8 @@ param prerequisiteCommand string = '/home/startup.sh'
 
 param deploymentTime string = utcNow()
 
+param enableAppServicePrivateEndpoint bool = true
+
 @description('The password to use for the MySQL Flexible Server admin account \'sqladmin\'.')
 @secure()
 param sqlPassword string
@@ -401,9 +403,8 @@ module webAppModule './modules/webapp/main.bicep' = {
     webAppName: webAppName
     appServicePlanName: planName
     location: location
-    // TODO: Consider deploying as P0V3 to ensure the deployment runs on a scale unit that supports P_v3 for future upgrades. GH issue #50
-    skuName: 'S1'
-    skuTier: 'Standard'
+    // Deploy as P0V3 to ensure the deployment runs on a scale unit that supports P_v3 for future upgrades. GH issue #50
+    skuName: 'P0V3'
     peSubnetId: privateEndpointSubnetId
     appInsights_connectionString: monitoring.outputs.appInsightsResourceId
     appInsights_instrumentationKey: monitoring.outputs.appInsightsInstrumentationKey
@@ -447,6 +448,8 @@ module webAppModule './modules/webapp/main.bicep' = {
     deploymentNameStructure: deploymentNameStructure
 
     uamiId: uamiModule.outputs.id
+
+    enablePrivateEndpoint: enableAppServicePrivateEndpoint
   }
 }
 

--- a/modules/kv/kv.bicep
+++ b/modules/kv/kv.bicep
@@ -11,10 +11,12 @@ param peSubnetId string
 
 param deploymentNameStructure string
 
-param roleAssignments array = [ {
+param roleAssignments array = [
+  {
     RoleDefinitionId: ''
     objectId: ''
-  } ]
+  }
+]
 param privateDnsZoneId string
 
 @secure()
@@ -60,14 +62,19 @@ module keyVaultSecretsModule 'kvSecrets.bicep' = {
   }
 }
 
-resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for roleAssignment in roleAssignments: {
-  scope: keyVault
-  name: guid(keyVault.id, roleAssignment.objectId, roleAssignment.RoleDefinitionId)
-  properties: {
-    roleDefinitionId: roleAssignment.RoleDefinitionId
-    principalId: roleAssignment.objectId
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for roleAssignment in roleAssignments: {
+    scope: keyVault
+    name: guid(keyVault.id, roleAssignment.objectId, roleAssignment.RoleDefinitionId)
+    properties: {
+      roleDefinitionId: roleAssignment.RoleDefinitionId
+      principalId: roleAssignment.objectId
+      principalType: contains(roleAssignment, 'principalType') && !empty(roleAssignment.principalType)
+        ? roleAssignment.principalType
+        : null
+    }
   }
-}]
+]
 
 resource pekeyVault 'Microsoft.Network/privateEndpoints@2022-07-01' = {
   name: 'pe-${keyVaultName}'

--- a/modules/networking/main.bicep
+++ b/modules/networking/main.bicep
@@ -34,3 +34,4 @@ module vNetModule 'vnet.bicep' = {
 
 output virtualNetworkId string = vNetModule.outputs.virtualNetworkId
 output subnets object = reduce(vNetModule.outputs.subnets, {}, (cur, next) => union(cur, next))
+output resourceGroupId string = resourceGroup.id

--- a/modules/networking/vnet.bicep
+++ b/modules/networking/vnet.bicep
@@ -25,21 +25,25 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-05-01' = {
         vnetAddressPrefix
       ]
     }
-    subnets: [for (subnet, i) in subnetDefsArray: {
-      name: subnet.key
-      properties: {
-        addressPrefix: subnet.value.addressPrefix
-        serviceEndpoints: contains(subnet.value, 'serviceEndpoints') ? subnet.value.serviceEndpoints : null
-        delegations: contains(subnet.value, 'delegation') && !empty(subnet.value.delegation) ? [
-          {
-            name: 'delegation'
-            properties: {
-              serviceName: subnet.value.delegation
-            }
-          }
-        ] : null
+    subnets: [
+      for (subnet, i) in subnetDefsArray: {
+        name: subnet.key
+        properties: {
+          addressPrefix: subnet.value.addressPrefix
+          serviceEndpoints: subnet.value.?serviceEndpoints
+          delegations: contains(subnet.value, 'delegation') && !empty(subnet.value.delegation)
+            ? [
+                {
+                  name: 'delegation'
+                  properties: {
+                    serviceName: subnet.value.delegation
+                  }
+                }
+              ]
+            : null
+        }
       }
-    }]
+    ]
 
     dhcpOptions: {
       dnsServers: customDnsIPs
@@ -53,19 +57,23 @@ output virtualNetworkId string = virtualNetwork.id
 // Retrieve the subnets as an array of existing resources
 // This is important because we need to ensure subnet return value is matched to the name of the subnet correctly - order matters
 // This works because the parent property is set to the virtual network, which means this won't be attempted until the VNet is created
-resource subnetRes 'Microsoft.Network/virtualNetworks/subnets@2022-05-01' existing = [for subnet in subnetDefsArray: {
-  name: subnet.key
-  parent: virtualNetwork
-}]
-
-output subnets array = [for i in range(0, length((subnetDefsArray))): {
-  '${subnetRes[i].name}': {
-    id: subnetRes[i].id
-    addressPrefix: subnetRes[i].properties.addressPrefix
-    // routeTableId: contains(subnetRes[i].properties, 'routeTable') ? subnetRes[i].properties.routeTable.id : null
-    // routeTableName: contains(subnetRes[i].properties, 'routeTable') ? routeTables[subnetRes[i].name].name : null
-    // networkSecurityGroupId: contains(subnetRes[i].properties, 'networkSecurityGroup') ? subnetRes[i].properties.networkSecurityGroup.id : null
-    // networkSecurityGroupName: contains(subnetRes[i].properties, 'networkSecurityGroup') ? networkSecurityGroups[subnetRes[i].name].name : null
-    // Add as many additional subnet properties as needed downstream
+resource subnetRes 'Microsoft.Network/virtualNetworks/subnets@2022-05-01' existing = [
+  for subnet in subnetDefsArray: {
+    name: subnet.key
+    parent: virtualNetwork
   }
-}]
+]
+
+output subnets array = [
+  for i in range(0, length((subnetDefsArray))): {
+    '${subnetRes[i].name}': {
+      id: subnetRes[i].id
+      addressPrefix: subnetRes[i].properties.addressPrefix
+      // routeTableId: contains(subnetRes[i].properties, 'routeTable') ? subnetRes[i].properties.routeTable.id : null
+      // routeTableName: contains(subnetRes[i].properties, 'routeTable') ? routeTables[subnetRes[i].name].name : null
+      // networkSecurityGroupId: contains(subnetRes[i].properties, 'networkSecurityGroup') ? subnetRes[i].properties.networkSecurityGroup.id : null
+      // networkSecurityGroupName: contains(subnetRes[i].properties, 'networkSecurityGroup') ? networkSecurityGroups[subnetRes[i].name].name : null
+      // Add as many additional subnet properties as needed downstream
+    }
+  }
+]

--- a/modules/sql/main.bicep
+++ b/modules/sql/main.bicep
@@ -18,10 +18,7 @@ param deploymentScriptName string
 
 @description('MySQL version')
 @allowed([
-  // TODO: Remove 5.7
-  '5.7'
   '8.0.21'
-  //'8.0.32'
 ])
 param mysqlVersion string = '8.0.21'
 
@@ -29,7 +26,7 @@ param mysqlVersion string = '8.0.21'
 param sqlAdminPasword string
 
 @description('Azure database for MySQL sku name ')
-param skuName string = 'Standard_B1s'
+param skuName string = 'Standard_B1ms'
 
 @description('Azure database for MySQL pricing tier')
 @allowed([

--- a/modules/webapp/main.bicep
+++ b/modules/webapp/main.bicep
@@ -41,6 +41,8 @@ param prerequisiteCommand string
 
 param existingPrivateDnsZonesResourceGroupId string = ''
 
+param timeZone string = 'UTC'
+
 param uamiId string
 
 // Disabling this check because this is not a secret; it's a reference to Key Vault
@@ -92,6 +94,8 @@ module appService 'webapp.bicep' = {
     uamiId: uamiId
 
     enablePrivateEndpoint: enablePrivateEndpoint
+
+    timeZone: timeZone
   }
 }
 

--- a/modules/webapp/main.bicep
+++ b/modules/webapp/main.bicep
@@ -3,7 +3,6 @@ param location string = resourceGroup().location
 param webAppName string
 param appServicePlanName string
 param skuName string
-param skuTier string
 param linuxFxVersion string = 'php|8.2'
 param dbHostName string
 #disable-next-line secure-secrets-in-params
@@ -27,6 +26,8 @@ param storageAccountContainerName string
 
 param appInsights_connectionString string
 param appInsights_instrumentationKey string
+
+param enablePrivateEndpoint bool
 
 param scmRepoUrl string
 param scmRepoBranch string
@@ -57,7 +58,6 @@ module appService 'webapp.bicep' = {
     appServicePlanName: appServicePlanName
     location: location
     skuName: skuName
-    skuTier: skuTier
     linuxFxVersion: linuxFxVersion
     tags: mergeTags
     dbHostName: dbHostName
@@ -90,6 +90,8 @@ module appService 'webapp.bicep' = {
     smtpPort: smtpPort
 
     uamiId: uamiId
+
+    enablePrivateEndpoint: enablePrivateEndpoint
   }
 }
 

--- a/modules/webapp/main.bicep
+++ b/modules/webapp/main.bicep
@@ -38,6 +38,8 @@ param redcapCommunityUsernameSecretRef string
 param redcapCommunityPasswordSecretRef string
 param prerequisiteCommand string
 
+param existingPrivateDnsZonesResourceGroupId string = ''
+
 param uamiId string
 
 // Disabling this check because this is not a secret; it's a reference to Key Vault
@@ -63,7 +65,9 @@ module appService 'webapp.bicep' = {
     dbPasswordSecretRef: dbPasswordSecretRef
     dbUserNameSecretRef: dbUserNameSecretRef
     peSubnetId: peSubnetId
-    privateDnsZoneId: privateDns.outputs.privateDnsId
+    privateDnsZoneId: empty(existingPrivateDnsZonesResourceGroupId)
+      ? privateDns.outputs.privateDnsId
+      : '${existingPrivateDnsZonesResourceGroupId}/providers/Microsoft.Network/privateDnsZones/${privateDnsZoneName}'
     integrationSubnetId: integrationSubnetId
 
     appInsights_connectionString: appInsights_connectionString
@@ -89,7 +93,7 @@ module appService 'webapp.bicep' = {
   }
 }
 
-module privateDns '../pdns/main.bicep' = {
+module privateDns '../pdns/main.bicep' = if (empty(existingPrivateDnsZonesResourceGroupId)) {
   name: take(replace(deploymentNameStructure, '{rtype}', 'app-dns'), 64)
   params: {
     privateDnsZoneName: privateDnsZoneName

--- a/modules/webapp/webapp.bicep
+++ b/modules/webapp/webapp.bicep
@@ -2,7 +2,6 @@ param webAppName string
 param appServicePlanName string
 param location string
 param skuName string
-param skuTier string
 param tags object
 param linuxFxVersion string
 
@@ -29,6 +28,8 @@ param prerequisiteCommand string
 param appInsights_connectionString string
 param appInsights_instrumentationKey string
 
+param enablePrivateEndpoint bool
+
 param smtpFQDN string = ''
 param smtpPort string = ''
 param smtpFromEmailAddress string = ''
@@ -48,7 +49,7 @@ resource appSrvcPlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   tags: tags
   sku: {
     name: skuName
-    tier: skuTier
+    //tier: skuTier
   }
   kind: 'linux'
   properties: {
@@ -76,10 +77,7 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
       ftpsState: 'FtpsOnly'
       appCommandLine: prerequisiteCommand
       appSettings: [
-        {
-          name: 'redcapAppZip'
-          value: redcapZipUrl
-        }
+        // REDCap runtime settings
         {
           name: 'DBHostName'
           value: dbHostName
@@ -96,6 +94,11 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           name: 'DBPassword'
           value: dbPasswordSecretRef
         }
+        // REDCap deployment settings
+        {
+          name: 'redcapAppZip'
+          value: redcapZipUrl
+        }
         {
           name: 'redcapCommunityUsername'
           value: redcapCommunityUsernameSecretRef
@@ -108,6 +111,7 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           name: 'DBSslCa'
           value: DBSslCa
         }
+        // SMTP, possibly legacy settings
         {
           name: 'smtpFQDN'
           value: smtpFQDN
@@ -120,6 +124,7 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           name: 'fromEmailAddress'
           value: smtpFromEmailAddress
         }
+        // END SMTP
         {
           name: 'APPINSIGHTS_INSTRUMENTATIONKEY'
           value: appInsights_instrumentationKey
@@ -132,6 +137,7 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
           value: '1'
         }
+        // EDOC configuration, used during deployment only
         {
           name: 'StorageKey'
           value: storageAccountKeySecretRef
@@ -144,9 +150,19 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           name: 'StorageContainerName'
           value: storageAccountContainerName
         }
+        // END EDOC
         {
           name: 'ENABLE_DYNAMIC_INSTALL'
           value: 'true'
+        }
+        {
+          name: 'PRE_BUILD_COMMAND'
+          value: 'apt-get update -qq && apt-get install default-mysql-client -yqq'
+        }
+        {
+          // HACK: 2024-09-24: svaelter: Re-added to ensure /home/site/ini/redcap.ini and /home/site/ini/extensions.ini gets processed
+          name: 'PHP_INI_SCAN_DIR'
+          value: '/usr/local/etc/php/conf.d:/home/site/ini'
         }
       ]
     }
@@ -177,10 +193,10 @@ resource sourcecontrol 'Microsoft.Web/sites/sourcecontrols@2022-09-01' = {
     branch: scmRepoBranch
     isManualIntegration: true
   }
-  dependsOn: [ privateDnsZoneGroupsWebApp ]
+  dependsOn: [privateDnsZoneGroupsWebApp]
 }
 
-resource peWebApp 'Microsoft.Network/privateEndpoints@2022-07-01' = {
+resource peWebApp 'Microsoft.Network/privateEndpoints@2022-07-01' = if (enablePrivateEndpoint) {
   name: 'pe-${webApp.name}'
   location: location
   properties: {
@@ -201,7 +217,7 @@ resource peWebApp 'Microsoft.Network/privateEndpoints@2022-07-01' = {
   }
 }
 
-resource privateDnsZoneGroupsWebApp 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-07-01' = {
+resource privateDnsZoneGroupsWebApp 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2022-07-01' = if (enablePrivateEndpoint) {
   name: 'privatednszonegroup'
   parent: peWebApp
   properties: {

--- a/modules/webapp/webapp.bicep
+++ b/modules/webapp/webapp.bicep
@@ -156,10 +156,6 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           value: 'true'
         }
         {
-          name: 'PRE_BUILD_COMMAND'
-          value: 'apt-get update -qq && apt-get install default-mysql-client -yqq'
-        }
-        {
           // HACK: 2024-09-24: svaelter: Re-added to ensure /home/site/ini/redcap.ini and /home/site/ini/extensions.ini gets processed
           name: 'PHP_INI_SCAN_DIR'
           value: '/usr/local/etc/php/conf.d:/home/site/ini'

--- a/modules/webapp/webapp.bicep
+++ b/modules/webapp/webapp.bicep
@@ -34,6 +34,8 @@ param smtpFQDN string = ''
 param smtpPort string = ''
 param smtpFromEmailAddress string = ''
 
+param timeZone string = 'UTC'
+
 // This is not a secret, it's a Key Vault reference
 #disable-next-line secure-secrets-in-params
 param storageAccountKeySecretRef string
@@ -159,6 +161,10 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           // Ensure /home/site/ini/redcap.ini and /home/site/ini/extensions.ini gets processed
           name: 'PHP_INI_SCAN_DIR'
           value: '/usr/local/etc/php/conf.d:/home/site/ini'
+        }
+        {
+          name: 'WEBSITE_TIME_ZONE'
+          value: timeZone
         }
       ]
     }

--- a/modules/webapp/webapp.bicep
+++ b/modules/webapp/webapp.bicep
@@ -156,7 +156,7 @@ resource webApp 'Microsoft.Web/sites@2022-03-01' = {
           value: 'true'
         }
         {
-          // HACK: 2024-09-24: svaelter: Re-added to ensure /home/site/ini/redcap.ini and /home/site/ini/extensions.ini gets processed
+          // Ensure /home/site/ini/redcap.ini and /home/site/ini/extensions.ini gets processed
           name: 'PHP_INI_SCAN_DIR'
           value: '/usr/local/etc/php/conf.d:/home/site/ini'
         }

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -90,11 +90,11 @@ cd /home/site/wwwroot
 
 wget --no-check-certificate https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem
 
-sed -i "s|hostname[[:space:]]*= '';|hostname = getenv('APPSETTING_DBHostName');|" database.php
-sed -i "s|db[[:space:]]*= '';|db = getenv('APPSETTING_DBName');|" database.php
-sed -i "s|username[[:space:]]*= '';|username = getenv('APPSETTING_DBUserName');|" database.php
-sed -i "s|password[[:space:]]*= '';|password = getenv('APPSETTING_DBPassword');|" database.php
-sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = getenv('APPSETTING_DBSslCa');|" database.php
+sed -i "s|hostname[[:space:]]*= '';|hostname = getenv('DBHostName');|" database.php
+sed -i "s|db[[:space:]]*= '';|db = getenv('DBName');|" database.php
+sed -i "s|username[[:space:]]*= '';|username = getenv('DBUserName');|" database.php
+sed -i "s|password[[:space:]]*= '';|password = getenv('DBPassword');|" database.php
+sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = getenv('DBSslCa');|" database.php
 
 sed -i "s/db_ssl_verify_server_cert = false;/db_ssl_verify_server_cert = true;/" database.php
 sed -i "s/$salt = '';/$salt = '$(echo $RANDOM | md5sum | head -c 20; echo;)';/" database.php
@@ -141,4 +141,4 @@ cp /home/site/repository/scripts/bash/postbuild.sh /home/site/deployments/tools/
 
 cp /home/site/repository/scripts/bash/startup.sh /home/startup.sh
 
-echo "mysql: $(which mysql)" >> /home/site/log-$stamp.txt
+#echo "mysql: $(which mysql)" >> /home/site/log-$stamp.txt

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -67,7 +67,7 @@ fi
 
 rm -f /home/site/wwwroot/hostingstart.html
 unzip -oq /tmp/redcap.zip -d /tmp/wwwroot 
-mv /tmp/wwwroot/redcap/* /home/site/wwwroot/
+mv -f /tmp/wwwroot/redcap/* /home/site/wwwroot/
 rm -rf /tmp/wwwroot
 rm /tmp/redcap.zip
 
@@ -83,11 +83,11 @@ cd /home/site/wwwroot
 
 wget --no-check-certificate https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem
 
-sed -i "s|hostname[[:space:]]*= '';|hostname = \$_ENV['\$APPSETTING_DBHostName'];|" database.php
-sed -i "s|db[[:space:]]*= '';|db = \$_ENV['\$APPSETTING_DBName'];|" database.php
-sed -i "s|username[[:space:]]*= '';|username = \$_ENV['\$APPSETTING_DBUserName'];|" database.php
-sed -i "s|password[[:space:]]*= '';|password = \$_ENV['\$APPSETTING_DBPassword'];|" database.php
-sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = \$_ENV['\$APPSETTING_DBSslCa'];|" database.php
+sed -i "s|hostname[[:space:]]*= '';|hostname = getenv('APPSETTING_DBHostName');|" database.php
+sed -i "s|db[[:space:]]*= '';|db = getenv('APPSETTING_DBName');|" database.php
+sed -i "s|username[[:space:]]*= '';|username = getenv('APPSETTING_DBUserName');|" database.php
+sed -i "s|password[[:space:]]*= '';|password = getenv('APPSETTING_DBPassword');|" database.php
+sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = getenv('APPSETTING_DBSslCa');|" database.php
 
 sed -i "s/db_ssl_verify_server_cert = false;/db_ssl_verify_server_cert = true;/" database.php
 sed -i "s/$salt = '';/$salt = '$(echo $RANDOM | md5sum | head -c 20; echo;)';/" database.php

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -135,6 +135,17 @@ cp /home/site/repository/scripts/bash/postbuild.sh /home/site/deployments/tools/
 
 ####################################################################################
 #
+# Configure REDCap cronjob to run every minute
+#
+####################################################################################
+
+echo "Configuring REDCap cronjob to run every minute" >> /home/site/log-$stamp.txt
+
+service cron start
+(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 
+
+####################################################################################
+#
 # Copy startup.sh /home for a custom startup
 #
 ####################################################################################

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -20,10 +20,8 @@ stamp=$(date +%Y-%m-%d-%H-%M)
 ####################################################################################
 
 echo "Configuring mysqli extension" >> /home/site/log-$stamp.txt
-cd /home/site
-# echo "extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/mysqlnd_azure.so
-# extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/mysqli.so" >> extensions.ini
-echo "extension=/usr/local/lib/php/extensions/no-debug-non-zts-20220829/mysqli.so" >> extensions.ini
+mkdir /home/site/ini
+echo "extension=/usr/local/lib/php/extensions/no-debug-non-zts-20220829/mysqli.so" >> /home/site/ini/extensions.ini
 
 ####################################################################################
 #
@@ -85,11 +83,11 @@ cd /home/site/wwwroot
 
 wget --no-check-certificate https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem
 
-sed -i "s|hostname[[:space:]]*= '';|hostname = '$APPSETTING_DBHostName';|" database.php
-sed -i "s|db[[:space:]]*= '';|db = '$APPSETTING_DBName';|" database.php
-sed -i "s|username[[:space:]]*= '';|username = '$APPSETTING_DBUserName';|" database.php
-sed -i "s|password[[:space:]]*= '';|password = '$APPSETTING_DBPassword';|" database.php
-sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = '$APPSETTING_DBSslCa';|" database.php
+sed -i "s|hostname[[:space:]]*= '';|hostname = $_ENV['$APPSETTING_DBHostName'];|" database.php
+sed -i "s|db[[:space:]]*= '';|db = $_ENV['$APPSETTING_DBName'];|" database.php
+sed -i "s|username[[:space:]]*= '';|username = $_ENV['$APPSETTING_DBUserName'];|" database.php
+sed -i "s|password[[:space:]]*= '';|password = $_ENV['$APPSETTING_DBPassword'];|" database.php
+sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = $_ENV['$APPSETTING_DBSslCa'];|" database.php
 
 sed -i "s/db_ssl_verify_server_cert = false;/db_ssl_verify_server_cert = true;/" database.php
 sed -i "s/$salt = '';/$salt = '$(echo $RANDOM | md5sum | head -c 20; echo;)';/" database.php
@@ -101,11 +99,13 @@ sed -i "s/$salt = '';/$salt = '$(echo $RANDOM | md5sum | head -c 20; echo;)';/" 
 ####################################################################################
 
 echo "Configuring REDCap recommended settings" >> /home/site/log-$stamp.txt
+
 sed -i "s|SMTP[[:space:]]*= ''|SMTP = '$APPSETTING_smtpFQDN'|" /home/site/repository/Files/settings.ini
 sed -i "s|smtp_port[[:space:]]*= |smtp_port = $APPSETTING_smtpPort|" /home/site/repository/Files/settings.ini
 sed -i "s|sendmail_from[[:space:]]*= ''|sendmail_from = '$APPSETTING_fromEmailAddress'|" /home/site/repository/Files/settings.ini
 sed -i "s|sendmail_path[[:space:]]*= ''|sendmail_path = '/usr/sbin/sendmail -t -i'|" /home/site/repository/Files/settings.ini
-cp /home/site/repository/Files/settings.ini /home/site/redcap.ini
+
+cp /home/site/repository/Files/settings.ini /home/site/ini/redcap.ini
 
 ####################################################################################
 #
@@ -115,7 +115,7 @@ cp /home/site/repository/Files/settings.ini /home/site/redcap.ini
 ####################################################################################
 
 echo "For better security, it is recommended that you enable the session.cookie_secure option in your web server's PHP.INI file" >> /home/site/log-$stamp.txt
-echo "session.cookie_secure = On" >> /home/site/redcap.ini
+echo "session.cookie_secure = On" >> /home/site/ini/redcap.ini
 
 ####################################################################################
 #

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -83,11 +83,11 @@ cd /home/site/wwwroot
 
 wget --no-check-certificate https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem
 
-sed -i "s|hostname[[:space:]]*= '';|hostname = $_ENV['$APPSETTING_DBHostName'];|" database.php
-sed -i "s|db[[:space:]]*= '';|db = $_ENV['$APPSETTING_DBName'];|" database.php
-sed -i "s|username[[:space:]]*= '';|username = $_ENV['$APPSETTING_DBUserName'];|" database.php
-sed -i "s|password[[:space:]]*= '';|password = $_ENV['$APPSETTING_DBPassword'];|" database.php
-sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = $_ENV['$APPSETTING_DBSslCa'];|" database.php
+sed -i "s|hostname[[:space:]]*= '';|hostname = \$_ENV['\$APPSETTING_DBHostName'];|" database.php
+sed -i "s|db[[:space:]]*= '';|db = \$_ENV['\$APPSETTING_DBName'];|" database.php
+sed -i "s|username[[:space:]]*= '';|username = \$_ENV['\$APPSETTING_DBUserName'];|" database.php
+sed -i "s|password[[:space:]]*= '';|password = \$_ENV['\$APPSETTING_DBPassword'];|" database.php
+sed -i "s|db_ssl_ca[[:space:]]*= '';|db_ssl_ca = \$_ENV['\$APPSETTING_DBSslCa'];|" database.php
 
 sed -i "s/db_ssl_verify_server_cert = false;/db_ssl_verify_server_cert = true;/" database.php
 sed -i "s/$salt = '';/$salt = '$(echo $RANDOM | md5sum | head -c 20; echo;)';/" database.php

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -135,17 +135,6 @@ cp /home/site/repository/scripts/bash/postbuild.sh /home/site/deployments/tools/
 
 ####################################################################################
 #
-# Configure REDCap cronjob to run every minute
-#
-####################################################################################
-
-echo "Configuring REDCap cronjob to run every minute" >> /home/site/log-$stamp.txt
-
-service cron start
-(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 
-
-####################################################################################
-#
 # Copy startup.sh /home for a custom startup
 #
 ####################################################################################

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -20,7 +20,7 @@ stamp=$(date +%Y-%m-%d-%H-%M)
 ####################################################################################
 
 echo "Configuring mysqli extension" >> /home/site/log-$stamp.txt
-mkdir /home/site/ini
+mkdir -p /home/site/ini
 echo "extension=/usr/local/lib/php/extensions/no-debug-non-zts-20220829/mysqli.so" >> /home/site/ini/extensions.ini
 
 ####################################################################################
@@ -30,6 +30,8 @@ echo "extension=/usr/local/lib/php/extensions/no-debug-non-zts-20220829/mysqli.s
 # make a call # to REDCap community site and download it
 #
 ####################################################################################
+
+redcapZipPath="/tmp/redcap.zip"
 
 cd /tmp
 if [ -z "$APPSETTING_redcapAppZip" ]; then
@@ -50,7 +52,7 @@ if [ -z "$APPSETTING_redcapAppZip" ]; then
     export APPSETTING_zipVersion="latest"
   fi
   
-  wget --method=post -O /tmp/redcap.zip -q --body-data="username=$APPSETTING_redcapCommunityUsername&password=$APPSETTING_redcapCommunityPassword&version=$APPSETTING_zipVersion&install=1" --header=Content-Type:application/x-www-form-urlencoded https://redcap.vanderbilt.edu/plugins/redcap_consortium/versions.php
+  wget --method=post -O $redcapZipPath -q --body-data="username=$APPSETTING_redcapCommunityUsername&password=$APPSETTING_redcapCommunityPassword&version=$APPSETTING_zipVersion&install=1" --header=Content-Type:application/x-www-form-urlencoded https://redcap.vanderbilt.edu/plugins/redcap_consortium/versions.php
 
   # check to see if the redcap.zip file contains the word error
   if [ -z "$(grep -i error redcap.zip)" ]; then
@@ -62,14 +64,14 @@ if [ -z "$APPSETTING_redcapAppZip" ]; then
 
 else
   echo "Downloading REDCap zip file from storage" >> /home/site/log-$stamp.txt
-  wget -q -O /tmp/redcap.zip $APPSETTING_redcapAppZip
+  wget -q -O $redcapZipPath $APPSETTING_redcapAppZip
 fi
 
-rm -f /home/site/wwwroot/hostingstart.html
-unzip -oq /tmp/redcap.zip -d /tmp/wwwroot 
+rm -rf /home/site/wwwroot/*
+unzip -oq $redcapZipPath -d /tmp/wwwroot 
 mv -f /tmp/wwwroot/redcap/* /home/site/wwwroot/
 rm -rf /tmp/wwwroot
-rm /tmp/redcap.zip
+rm -f $redcapZipPath
 
 ####################################################################################
 #

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -133,3 +133,5 @@ cp /home/site/repository/scripts/bash/postbuild.sh /home/site/deployments/tools/
 ####################################################################################
 
 cp /home/site/repository/scripts/bash/startup.sh /home/startup.sh
+
+which mysql >> /home/site/log-$stamp.txt

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -134,4 +134,4 @@ cp /home/site/repository/scripts/bash/postbuild.sh /home/site/deployments/tools/
 
 cp /home/site/repository/scripts/bash/startup.sh /home/startup.sh
 
-which mysql >> /home/site/log-$stamp.txt
+echo "mysql: $(which mysql)" >> /home/site/log-$stamp.txt

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -67,8 +67,13 @@ else
   wget -q -O $redcapZipPath $APPSETTING_redcapAppZip
 fi
 
+echo "Unzipping redcap.zip" >> /home/site/log-$stamp.txt
+
 rm -rf /home/site/wwwroot/*
 unzip -oq $redcapZipPath -d /tmp/wwwroot 
+
+echo "Moving REDCap files to wwwroot" >> /home/site/log-$stamp.txt
+
 mv -f /tmp/wwwroot/redcap/* /home/site/wwwroot/
 rm -rf /tmp/wwwroot
 rm -f $redcapZipPath

--- a/scripts/bash/install.sh
+++ b/scripts/bash/install.sh
@@ -7,7 +7,7 @@
 
 echo -e "\nHello from install.sh"
 
-which mysql
+echo "mysql: $(which mysql)"
 
 ####################################################################################
 #

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -16,5 +16,12 @@ apt-get update -qq && apt-get install cron sendmail -yqq
 #
 ####################################################################################
 
+# Export environment variables so cron can run cron.php successfully
+export APPSETTING_DBUserName=$APPSETTING_DBUserName
+export APPSETTING_DBHostName=$APPSETTING_DBHostName
+export APPSETTING_DBPassword=$APPSETTING_DBPassword
+export APPSETTING_DBName=$APPSETTING_DBName
+export APPSETTING_DBSslCa=$APPSETTING_DBSslCa
+
 service cron start
 (crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -8,7 +8,7 @@ echo "Custom container startup"
 #
 ####################################################################################
 
-apt-get update -qq && apt-get install sendmail -yqq
+apt-get update -qq && apt-get install cron sendmail -yqq
 
 ####################################################################################
 #

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -19,8 +19,8 @@ apt-get update -qq && apt-get install cron sendmail -yqq
 # Export the database connection environment variables to /etc/environment so cron can use them
 # We do this in startup.sh so that each container instance will get this file (it's outside of /home so not persisted)
 # and also because then updates to the environment variables will be picked up by cron
-echo "DBHostName=$DBHostName" >> /etc/environment
-echo "DBName=$DBName" >> /etc/environment
+echo "DBHostName=$DBHostName" > /etc/environment # Overwrite the file with the first statement
+echo "DBName=$DBName" >> /etc/environment # Append all the other lines
 echo "DBUserName=$DBUserName" >> /etc/environment
 echo "DBPassword=$DBPassword" >> /etc/environment
 echo "DBSslCa=$DBSslCa" >> /etc/environment

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -16,5 +16,5 @@ apt-get update -qq && apt-get install sendmail -yqq
 #
 ####################################################################################
 
-# service cron start
-# (crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 
+service cron start
+(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -16,12 +16,14 @@ apt-get update -qq && apt-get install cron sendmail -yqq
 #
 ####################################################################################
 
-# Export environment variables so cron can run cron.php successfully
-export APPSETTING_DBUserName=$APPSETTING_DBUserName
-export APPSETTING_DBHostName=$APPSETTING_DBHostName
-export APPSETTING_DBPassword=$APPSETTING_DBPassword
-export APPSETTING_DBName=$APPSETTING_DBName
-export APPSETTING_DBSslCa=$APPSETTING_DBSslCa
+# Export the database connection environment variables to /etc/environment so cron can use them
+# We do this in startup.sh so that each container instance will get this file (it's outside of /home so not persisted)
+# and also because then updates to the environment variables will be picked up by cron
+echo "DBHostName=$DBHostName" >> /etc/environment
+echo "DBName=$DBName" >> /etc/environment
+echo "DBUserName=$DBUserName" >> /etc/environment
+echo "DBPassword=$DBPassword" >> /etc/environment
+echo "DBSslCa=$DBSslCa" >> /etc/environment
 
 service cron start
 (crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -8,7 +8,7 @@ echo "Custom container startup"
 #
 ####################################################################################
 
-apt-get update -qq && apt-get install sendmail cron -yqq
+apt-get update -qq && apt-get install sendmail -yqq
 
 ####################################################################################
 #
@@ -16,5 +16,5 @@ apt-get update -qq && apt-get install sendmail cron -yqq
 #
 ####################################################################################
 
-service cron start
-(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 
+# service cron start
+# (crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -25,5 +25,7 @@ echo "DBUserName=$DBUserName" >> /etc/environment
 echo "DBPassword=$DBPassword" >> /etc/environment
 echo "DBSslCa=$DBSslCa" >> /etc/environment
 
+sed -i "s|date.timezone=UTC|date.timezone=$WEBSITE_TIME_ZONE|" /usr/local/etc/php/conf.d/php.ini
+
 service cron start
-(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab 
+(crontab -l 2>/dev/null; echo "* * * * * /usr/local/bin/php /home/site/wwwroot/cron.php > /dev/null")|crontab


### PR DESCRIPTION
This update optionally enables specifying an existing Azure virtual network to deploy resources into. 

When setting that parameter value, you must also set the parameter for the resource group ID of existing private DNS zones for blob, Key Vault, MySQL, and App Service. Further, you must also specify the `subnets` parameter to specify the names of existing subnets for private endpoints, MySQL private access, and App Service virtual network integration.

Closes #34, even though this deployment code does not perform the peering. However, the existing virtual network can be peered to other networks before or after the REDCap deployment.

New parameters have been added to the main.bicep to support this:

- `existingVirtualNetworkId`
- `existingPrivateDnsZonesResourceGroupId`
- `subnets`
- `enableAppServicePrivateEndpoint` (closes #83)

Also closes #58.

Also closes #38.

Also closes #93.