### PR TITLE
Fix to allow ImageMagick to read PDFs for REDCap

### DIFF
--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -88,7 +88,7 @@ echo "Updating database connection info in database.php" >> /home/site/log-$stam
 
 cd /home/site/wwwroot
 
-wget --no-check-certificate https://dl.cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem
+wget --no-check-certificate -O "${APPSETTING_DBSslCa:-/home/site/wwwroot/DigiCertGlobalRootCA.crt.pem}" https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem
 
 sed -i "s|hostname[[:space:]]*= '';|hostname = getenv('DBHostName');|" database.php
 sed -i "s|db[[:space:]]*= '';|db = getenv('DBName');|" database.php

--- a/scripts/bash/deploy.sh
+++ b/scripts/bash/deploy.sh
@@ -26,10 +26,13 @@ echo "extension=/usr/local/lib/php/extensions/no-debug-non-zts-20220829/mysqli.s
 ####################################################################################
 #
 # Download REDCap zip file and unzip to wwwroot
-# If zip file path exists just download it; otherwise 
+# If zip file path exists just download it; otherwise
 # make a call # to REDCap community site and download it
 #
 ####################################################################################
+
+echo "Installing unzip" >> "/home/site/log-${stamp}.txt"
+apt-get update -qq && apt-get install -yqq unzip
 
 redcapZipPath="/tmp/redcap.zip"
 
@@ -51,7 +54,7 @@ if [ -z "$APPSETTING_redcapAppZip" ]; then
     echo "zipVersion is null or empty. Setting to latest" >> /home/site/log-$stamp.txt
     export APPSETTING_zipVersion="latest"
   fi
-  
+
   wget --method=post -O $redcapZipPath -q --body-data="username=$APPSETTING_redcapCommunityUsername&password=$APPSETTING_redcapCommunityPassword&version=$APPSETTING_zipVersion&install=1" --header=Content-Type:application/x-www-form-urlencoded https://redcap.vumc.org/plugins/redcap_consortium/versions.php
 
   # check to see if the redcap.zip file contains the word error
@@ -70,7 +73,7 @@ fi
 echo "Unzipping redcap.zip" >> /home/site/log-$stamp.txt
 
 rm -rf /home/site/wwwroot/*
-unzip -oq $redcapZipPath -d /tmp/wwwroot 
+unzip -oq $redcapZipPath -d /tmp/wwwroot
 
 echo "Moving REDCap files to wwwroot" >> /home/site/log-$stamp.txt
 
@@ -116,7 +119,7 @@ cp /home/site/repository/Files/settings.ini /home/site/ini/redcap.ini
 
 ####################################################################################
 #
-# For better security, it is recommended that you enable the 
+# For better security, it is recommended that you enable the
 # session.cookie_secure option in your web server's PHP.INI file
 #
 ####################################################################################

--- a/scripts/bash/install.sh
+++ b/scripts/bash/install.sh
@@ -9,9 +9,12 @@ echo -e "\nHello from install.sh"
 
 echo "mysql: $(which mysql)"
 
+# Azure MySQL Flexible Server uses DigiCert Global Root G2 for TLS
+wget -q --no-check-certificate -O /home/site/wwwroot/DigiCertGlobalRootCA.crt.pem https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem
+
 ####################################################################################
 #
-# Update additional configuration settings including 
+# Update additional configuration settings including
 # user file uploading settings to Azure Blob Storage
 #
 ####################################################################################

--- a/scripts/bash/startup.sh
+++ b/scripts/bash/startup.sh
@@ -12,6 +12,14 @@ apt-get update -qq && apt-get install cron sendmail -yqq
 
 ####################################################################################
 #
+# Allow Imagick to read PDF files (required for REDCap PDF rendering)
+#
+####################################################################################
+
+[ -f /etc/ImageMagick-6/policy.xml ] && sed -i 's~<policy domain="coder" rights="none" pattern="PDF" />~<policy domain="coder" rights="read" pattern="PDF" />~' /etc/ImageMagick-6/policy.xml
+
+####################################################################################
+#
 # Configure REDCap cronjob to run every minute
 #
 ####################################################################################


### PR DESCRIPTION
Update the App Service custom startup script so ImageMagick can read PDF files, which REDCap needs for PDF rendering.
In `startup.sh`, adjust `/etc/ImageMagick-6/policy.xml`: set the PDF coder policy from `rights="none"` to `rights="read"`.
